### PR TITLE
Proposition: Remove section commanding only one new-line between methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,17 +256,6 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
     end
     ```
 
-* <a name="newline-between-methods"></a>Include one, but no more than one, new
-    line between methods.<sup>[[link](#newline-between-methods)]</sup>
-
-    ```ruby
-    def a
-    end
-
-    def b
-    end
-    ```
-
 * <a name="method-def-empty-lines"></a>Use a single empty line to break between
     statements to break up methods into logical paragraphs internally.
     <sup>[[link](#method-def-empty-lines)]</sup>


### PR DESCRIPTION
Typically, one new line is appropriate.

However, -sometimes- I find it helpful to add 2-3 lines to group methods togehter and distinguish them from other methods. I find that this helps draw out the relationships between the methods and highlight parallel structures.

I also find it helpful to distinguigh the top-level-happy-path, 'perform'-type do-er methods (which are sometimes a bit procedural) from component-part contributing methods. Sometimes there is reason for these lesser, almost internatl methods to not be private, and additional space helps read the code faster.

Also, sometimes there is a logical group to methods, but not quite reason enought to extract these groups out into seperate objects yet. In that case, adding additional space to make groups helps leave a rough-edge.