### PR TITLE
Remove ambiguity in params allignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Airbnb also maintains a [JavaScript Style Guide][airbnb-javascript].
       ...
     end
 
-    # good
+    # bad
     def self.create_translation(phrase_id,
                                 phrase_key,
                                 target_locale,


### PR DESCRIPTION
Why:

* both the below options were previouls good but we've had a number of
  discussions around what we want. This change lands on a single one
  (pushing code as far left as possible).

This change addresses the need by:

* removing the ambiguity and stating that when method params are broken
  onto multiple lines put one on each line and indent once from the
  method declaration. This change makes it easier to scan the list.